### PR TITLE
add leaderGuide_toggle_show

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,15 @@ Don't update the guide automatically: (Not recommended)
 let g:leaderGuide_run_map_on_popup = 0
 ```
 
+You can toggle it off (just not show the shortcut window) and then reopen it
+```vim
+    map <leader>lt :LeaderGuideToggle<CR>
+```
+If You just want to use the keyMap and not show the shortcut window, you should stick this in your vimrc:
+```vim
+    let g:leaderGuide_toggle_show = 0
+```
+
 The update is almost instantaneous and will only run when the guide
 actually pops up. Apart from that the automatic update has no performance impact.
 

--- a/autoload/leaderGuide.vim
+++ b/autoload/leaderGuide.vim
@@ -294,28 +294,35 @@ endfunction " }}}
 
 
 function! s:start_buffer() " {{{
-    let s:winv = winsaveview()
-    let s:winnr = winnr()
-    let s:winres = winrestcmd()
-    call s:winopen()
-    let layout = s:calc_layout()
-    let string = s:create_string(layout)
-
-    if g:leaderGuide_max_size
-        let layout.win_dim = min([g:leaderGuide_max_size, layout.win_dim])
-    endif
-
-    setlocal modifiable
-    if g:leaderGuide_vertical
-        noautocmd execute 'vert res '.layout.win_dim
-    else
-        noautocmd execute 'res '.layout.win_dim
-    endif
-    silent 1put!=string
-    normal! gg"_dd
-    setlocal nomodifiable
+    call s:init_window()
     call s:wait_for_input()
 endfunction " }}}
+function! s:init_window() "{{{
+    if g:leaderGuide_toggle_show
+        let s:winv = winsaveview()
+        let s:winnr = winnr()
+        let s:winres = winrestcmd()
+        call s:winopen()
+    endif
+
+    let layout = s:calc_layout()
+    let string = s:create_string(layout)
+    if g:leaderGuide_toggle_show
+        if g:leaderGuide_max_size
+            let layout.win_dim = min([g:leaderGuide_max_size, layout.win_dim])
+        endif
+
+        setlocal modifiable
+        if g:leaderGuide_vertical
+            noautocmd execute 'vert res '.layout.win_dim
+        else
+            noautocmd execute 'res '.layout.win_dim
+        endif
+        silent 1put!=string
+        normal! gg"_dd
+        setlocal nomodifiable
+    endif
+endfunction"}}}
 function! s:handle_input(input) " {{{
     call s:winclose()
     if type(a:input) ==? type({})
@@ -373,6 +380,9 @@ function! s:winopen() " {{{
     setlocal statusline=\ Leader\ Guide
 endfunction " }}}
 function! s:winclose() " {{{
+    if g:leaderGuide_toggle_show == 0
+        return
+    endif
     noautocmd execute s:gwin.'wincmd w'
     if s:gwin == winnr()
         close
@@ -469,6 +479,9 @@ function! leaderGuide#start(vis, dict) " {{{
     let s:lmap = a:dict
     call s:start_buffer()
 endfunction " }}}
+function! leaderGuide#toggle() "{{{
+    let g:leaderGuide_toggle_show = !g:leaderGuide_toggle_show
+endfunction"}}}
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/leaderGuide.vim
+++ b/plugin/leaderGuide.vim
@@ -38,6 +38,10 @@ if !exists("g:leaderGuide_max_size")
     let g:leaderGuide_max_size = 0
 endif
 
+if !exists("g:leaderGuide_toggle_show") 
+    let g:leaderGuide_toggle_show = 1
+endif
+
 if !exists("g:leaderGuide_submode_mappings")
     let g:leaderGuide_submode_mappings = {'<C-C>': "win_close"}
 endif
@@ -54,6 +58,7 @@ if !leaderGuide#has_configuration()
     call leaderGuide#register_prefix_descriptions('', 'g:leaderGuide_map')
 endif
 
+command -nargs=0 LeaderGuideToggle call leaderGuide#toggle()
 command -nargs=1 LeaderGuideD call leaderGuide#start('0', <args>)
 command -range -nargs=1 LeaderGuideVisualD call leaderGuide#start('1', <args>)
 


### PR DESCRIPTION
You can toggle it off (just not show the shortcut window) and then reopen it
```vim
    map <leader>lt :LeaderGuideToggle<CR>
```
If You just want to use the keyMap and not show the shortcut window, you should stick this in your vimrc:
```vim
    let g:leaderGuide_toggle_show = 0
```