### PR TITLE
Input loop [fix for #51]

### DIFF
--- a/autoload/leaderGuide.vim
+++ b/autoload/leaderGuide.vim
@@ -380,6 +380,10 @@ function! s:wait_for_input() " {{{
     redraw
     "let inp = input("")
     let curr_inp = input("")
+    while len(curr_inp) > 1
+      echom " is not a recognised mapping"
+      let curr_inp = input("")
+    endwhile
     if curr_inp ==? ''
         call s:winclose()
     elseif match(curr_inp, "^<LGCMD>submode") == 0


### PR DESCRIPTION
Fix for #51.

If the input isn't processed immediately, the map is wrong, the input is longer than one character - try again.

It's not exactly graceful, but it's functional.