### PR TITLE
Allow renaming mappings without defining a command

### DIFF
--- a/autoload/leaderGuide.vim
+++ b/autoload/leaderGuide.vim
@@ -66,6 +66,10 @@ function! s:merge(dict_t, dict_o) " {{{
                     call s:merge(target[k."m"], other[k."m"])
                 endif
             endif
+        elseif type(target[k]) == type('') && has_key(other, k) && k !=? 'name'
+            let target[k] = [other[k][0], target[k]]
+        elseif type(target[k]) == type('') && !has_key(other, k) && k !=? 'name'
+            unlet target[k]
         endif
     endfor
     call extend(target, other, "keep")


### PR DESCRIPTION
This allows the user to change the name of a mapping like this:

```viml
let g:lmap.s = 'Search'
```
instead of
```viml
let g:lmap.s = [':grep ' : 'Search']
``` 